### PR TITLE
fix(claim-dapp): replace placeholder and minor fixes

### DIFF
--- a/src/components/Claim.tsx
+++ b/src/components/Claim.tsx
@@ -10,7 +10,7 @@ import { Spinner, ExternalLink } from "../assets/icons";
 import { ReactComponent as UnstyledLogo } from "../assets/kpi-frame.svg";
 import { useOptionsClaim, usePayouts } from "../hooks";
 import { etherscanUrlFromTx } from "../utils";
-import { expiryDate } from "../config";
+import { expiryDate, optionsName } from "../config";
 type ClaimProps = {
   onCancel?: () => void;
 };
@@ -36,11 +36,13 @@ const Claim: React.FC<ClaimProps> = ({ onCancel }) => {
         </Heading>
       </Header>
       <Content>
-        <OptionName>uTVL-0621</OptionName>
+        <OptionName>{optionsName}</OptionName>
         <Metrics>
           <div>
             <Label>Quantity</Label>
-            <Value>{payouts?.quantity ?? 0}</Value>
+            <Value>
+              {payouts?.quantity ?? 0} <Unit>{optionsName}</Unit>
+            </Value>
           </div>
           <div>
             <Label>Expiry</Label>
@@ -48,15 +50,21 @@ const Claim: React.FC<ClaimProps> = ({ onCancel }) => {
           </div>
           <div>
             <Label>Current Payout</Label>
-            <Value>{payouts?.currentPayout ?? "-"}</Value>
+            <Value>
+              {payouts?.currentPayout ?? "-"} <Unit>UMA</Unit>
+            </Value>
           </div>
           <div>
             <Label>Min. Payout</Label>
-            <Value>{payouts?.minPayout ?? "-"}</Value>
+            <Value>
+              {payouts?.minPayout ?? "-"} <Unit>UMA</Unit>
+            </Value>
           </div>
           <div>
             <Label>Max. Payout</Label>
-            <Value>{payouts?.maxPayout ?? "-"}</Value>
+            <Value>
+              {payouts?.maxPayout ?? "-"} <Unit>UMA</Unit>
+            </Value>
           </div>
         </Metrics>
       </Content>
@@ -118,3 +126,4 @@ const EtherscanLink = tw(
   Link
 )`mt-4 p-2 text-primary text-right hover:underline`;
 const LinkIcon = tw(ExternalLink)`w-3 h-3 inline-block`;
+const Unit = tw.span`text-gray text-sm font-light ml-1`;

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -20,10 +20,14 @@ import { MaxWidthWrapper } from "./Wrappers";
 import Heading from "./Heading";
 import Modal from "./Modal";
 import Settings from "./Settings";
+import Link from "./Link";
 import Claim from "./Claim";
 import Metrics from "./Metrics";
 import { optionsName } from "../config";
 
+const MoreInfoLink = tw(Link)`
+  text-xl no-underline
+`;
 const defaultMetrics = {
   tvl: {
     value: "$0",
@@ -31,11 +35,18 @@ const defaultMetrics = {
     description: (
       <div>
         <div>UMA’s Total Value Locked (TVL)</div>
+        <MoreInfoLink
+          href="https://monitor.simpleid.xyz/d/x4CYPILGk/uma?orgId=1"
+          target="_blank"
+          rel="noopener norefferrer"
+        >
+          More Info
+        </MoreInfoLink>
       </div>
     ),
   },
   maxReward: {
-    value: "2,000,000",
+    value: "0",
     quantifier: "UMA",
     description: "Maximum reward",
     extendedDescription: (
@@ -47,7 +58,7 @@ const defaultMetrics = {
     ),
   },
   currentReward: {
-    value: "325,000",
+    value: "0",
     quantifier: "UMA",
     description: "Current expected reward",
     extendedDescription: (
@@ -59,7 +70,7 @@ const defaultMetrics = {
     ),
   },
   supply: {
-    value: "100,000",
+    value: "0",
     description: "KPI options in circulation",
     extendedDescription: (
       <p>
@@ -69,7 +80,7 @@ const defaultMetrics = {
     ),
   },
   multiplier: {
-    value: "1x",
+    value: "0x",
     description: "Current option multiplier",
     extendedDescription: (
       <p>

--- a/src/components/InfoList.tsx
+++ b/src/components/InfoList.tsx
@@ -7,12 +7,14 @@ import { Info as UnstyledIcon } from "../assets/icons";
 export type InfoProps = {
   label: string;
   value: string | number;
+  unit?: string;
   description?: React.ReactNode;
 };
 
 const Info: React.FC<InfoProps> = ({
   label,
   value,
+  unit,
   description,
 }: InfoProps) => {
   const {
@@ -40,7 +42,9 @@ const Info: React.FC<InfoProps> = ({
           <InfoIcon onMouseOver={handleMouseOver} onMouseLeave={hideTooltip} />
         )}
       </Label>
-      <span>{value}</span>
+      <span>
+        {value} <Unit>{unit}</Unit>
+      </span>
       {tooltipOpen && (
         <Tooltip left={tooltipLeft} top={tooltipTop}>
           {description}
@@ -72,3 +76,4 @@ const InfoIcon = styled(UnstyledIcon)`
   ${tw`relative top-1 hover:cursor-pointer`};
   margin-left: 10px;
 `;
+const Unit = tw.span`text-gray text-xs font-light ml-1`;

--- a/src/components/KPIOptions.tsx
+++ b/src/components/KPIOptions.tsx
@@ -23,39 +23,48 @@ const defaultInfos: Record<string, InfoProps> = {
   quantity: {
     label: "Quantity",
     value: "-",
+    unit: `${optionsName}`,
   },
   expiry: {
     label: "Expiry",
-    value: expiryDate,
+    value: expiryDate.replace(/UTC/g, ""),
+    description: (
+      <span>
+        The <strong>UTC</strong> time at which your options will{" "}
+        <strong>expire</strong>.
+      </span>
+    ),
   },
   minPayout: {
     label: "Min. Payout",
     value: "-",
+    unit: "UMA",
     description: (
       <span>
         The <strong>minimum</strong> amount of UMA all of your {optionsName}{" "}
-        options will be worth <strong>at the current UMA price</strong>
+        options will be worth <strong>based on UMA’s current TVL</strong>.
       </span>
     ),
   },
   currentPayout: {
     label: "Current Payout",
     value: "-",
+    unit: "UMA",
     description: (
       <span>
         The <strong>current</strong> amount of UMA all of your {optionsName}{" "}
-        options are worth <strong>at the current UMA price</strong>
+        options are worth <strong>based on UMA’s current TVL</strong>.
       </span>
     ),
   },
   maxPayout: {
     label: "Max. Payout",
     value: "-",
+    unit: "UMA",
     description: (
       <span>
         The <strong>maximum</strong> amount of UMA all of your {optionsName}{" "}
-        options can be worth if UMA’s TVL reaches $2 billion{" "}
-        <strong>at the current UMA price</strong>
+        options can be worth if UMA’s TVL reaches <strong>$2 billion</strong>.
       </span>
     ),
   },

--- a/src/hooks/usePayouts.ts
+++ b/src/hooks/usePayouts.ts
@@ -20,9 +20,10 @@ export function usePayouts() {
   const quantity = parseFloat(
     ethers.utils.formatUnits(ethers.BigNumber.from(claim?.amount ?? 0), "ether")
   );
-  const minPayout = generalMinPayout * quantity;
-  const maxPayout = generalMaxPayout * quantity;
-  const currentPayout = Number(generalCurrentPayout) * quantity;
+  const minPayout = Math.round(100 * generalMinPayout * quantity) / 100;
+  const maxPayout = Math.round(100 * (generalMaxPayout * quantity)) / 100;
+  const currentPayout =
+    Math.round(100 * (Number(generalCurrentPayout) * quantity)) / 100;
   return {
     quantity,
     tvl,


### PR DESCRIPTION
Adjusts the claim portal based on feedback received, this PR:

- Re introduces the `MoreInfo` link to the external dashboard
- Replaces all placeholders with 0 instead of random values
- Adds units to options and payout info
- fixes a rounding issue in the payouts by rounding them all to 2 significant digits 

Signed-off-by: Francesco Baccetti <francesco@umaproject.org>