### PR TITLE
feat(claim-dapp): separate useConnection from Onboard

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -23,6 +23,7 @@ import Settings from "./Settings";
 import Link from "./Link";
 import Metrics from "./Metrics";
 import { optionsName } from "../config";
+import { useOnboard } from "../hooks/useOnboard";
 
 const MoreInfoLink = tw(Link)`
   text-xl no-underline
@@ -94,14 +95,15 @@ type HeroProps = {
   onClaim: () => void;
 };
 const Hero: React.FC<HeroProps> = ({ onClaim }) => {
-  const { isConnected, connect } = useConnection();
+  const { isConnected } = useConnection();
+  const { initOnboard } = useOnboard();
   const handleCTAClick = React.useCallback(() => {
     if (isConnected) {
       onClaim();
     } else {
-      connect();
+      initOnboard();
     }
-  }, [connect, isConnected, onClaim]);
+  }, [initOnboard, isConnected, onClaim]);
   const {
     modalRef: settingsModalRef,
     isOpen: isSettingsOpen,

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -4,6 +4,7 @@ import Button from "./Button";
 import UnstyledHeading from "./Heading";
 
 import { useConnection } from "../hooks";
+import { useOnboard } from "../hooks/useOnboard";
 
 type PingProps = { isConnected: boolean };
 const PingOuter = tw.div`
@@ -25,14 +26,15 @@ type SettingsProps = {
   onComplete: () => void;
 };
 const Settings: React.FC<SettingsProps> = ({ onComplete }) => {
-  const { account, onboard, isConnected, disconnect } = useConnection();
+  const { account, connector, isConnected } = useConnection();
+  const { resetOnboard } = useOnboard();
 
   const handleRemove = React.useCallback(() => {
-    disconnect();
+    resetOnboard();
     onComplete();
-  }, [disconnect, onComplete]);
+  }, [resetOnboard, onComplete]);
 
-  const walletName = onboard?.getState().wallet.name;
+  const walletName = connector?.getState().wallet.name;
 
   return (
     <Wrapper>

--- a/src/hooks/useOnboard.tsx
+++ b/src/hooks/useOnboard.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Wallet } from "bnc-onboard/dist/src/interfaces";
 import Onboard from "bnc-onboard";
-import { ethers } from "ethers";
 
 import { useConnection } from "./useConnection";
 import { onboardBaseConfig } from "../config";
@@ -30,14 +29,10 @@ export function useOnboard() {
           },
           wallet: async (wallet: Wallet) => {
             if (wallet.provider) {
-              const provider = new ethers.providers.Web3Provider(
-                wallet.provider
-              );
-              const signer = provider.getSigner();
+              const provider = wallet.provider;
 
               update({
                 provider,
-                signer,
               });
             }
           },

--- a/src/hooks/useOnboard.tsx
+++ b/src/hooks/useOnboard.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Wallet } from "bnc-onboard/dist/src/interfaces";
+import Onboard from "bnc-onboard";
+import { ethers } from "ethers";
+
+import { useConnection } from "./useConnection";
+import { onboardBaseConfig } from "../config";
+import { UnsupportedChainIdError, isValidChainId } from "../utils/chainId";
+
+export function useOnboard() {
+  const { connect, disconnect, update, setError } = useConnection();
+  const instance = React.useMemo(
+    () =>
+      Onboard({
+        ...onboardBaseConfig(),
+        subscriptions: {
+          address: (address: string) => {
+            update({ account: address });
+          },
+          network: (networkId: number) => {
+            const error = isValidChainId(networkId)
+              ? undefined
+              : new UnsupportedChainIdError(networkId);
+            update({
+              chainId: networkId,
+            });
+            if (error) {
+              setError(error);
+            }
+          },
+          wallet: async (wallet: Wallet) => {
+            if (wallet.provider) {
+              const provider = new ethers.providers.Web3Provider(
+                wallet.provider
+              );
+              const signer = provider.getSigner();
+
+              update({
+                provider,
+                signer,
+              });
+            }
+          },
+        },
+      }),
+    [setError, update]
+  );
+  const initOnboard = React.useCallback(async () => {
+    try {
+      await instance.walletSelect();
+      await instance.walletCheck();
+      connect({ connector: instance });
+    } catch (err) {
+      setError(err);
+    }
+  }, [connect, instance, setError]);
+  const resetOnboard = React.useCallback(() => {
+    instance.walletReset();
+    disconnect();
+  }, [instance, disconnect]);
+  return { initOnboard, resetOnboard };
+}

--- a/src/hooks/useOptionsClaim.tsx
+++ b/src/hooks/useOptionsClaim.tsx
@@ -102,7 +102,7 @@ export const OptionsProvider: React.FC = ({ children, ...delegated }) => {
       // reset any erros we might have had previously
       dispatch({ type: "set error", error: null });
       const merkleDistributor = new ethers.Contract(
-        contracts.getMerkleDistributorAddress(chainId),
+        contracts.getMerkleDistributorAddress(chainId as any),
         contracts.merkleDistributorABI,
         signer
       );

--- a/src/hooks/useOptionsSupply.ts
+++ b/src/hooks/useOptionsSupply.ts
@@ -9,7 +9,7 @@ export function useOptionsSupply() {
   const { provider, chainId } = useConnection();
   const { data, isLoading, error } = useQuery<ethers.BigNumber>(
     ["kpi options supply", provider?.connection, chainId],
-    () => getOptionsSupply(provider, chainId)
+    () => getOptionsSupply(provider, chainId as any)
   );
 
   return {
@@ -20,8 +20,8 @@ export function useOptionsSupply() {
 }
 
 async function getOptionsSupply(
-  web3Provider: ethers.providers.Web3Provider | null,
-  _chainId: ValidChainId | null
+  web3Provider?: ethers.providers.Web3Provider,
+  _chainId?: ValidChainId
 ) {
   const chainId = _chainId ?? 1;
   const provider =


### PR DESCRIPTION
**Motivation**

This PR separates the `useConnection` hook from Onboard and makes it easier to test and reuse across apps




**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested
