### PR TITLE
fix: expiration payout to 2 decimals instead of 3

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -142,7 +142,7 @@ const minPayout = 0.1;
 export const expirationPayout = Math.max(
   minPayout,
   Math.min(maxPayout, expirationTvl / 10 ** 9)
-).toFixed(3);
+).toFixed(2);
 
 export const hasExpired =
   Boolean(process.env.REACT_APP_PUBLIC_HAS_EXPIRED) ??


### PR DESCRIPTION
Signed-off-by: David Adams <david@adams.software>

closes #21 