### PR TITLE
fix(claim-dapp): add allowance check before approve

### DIFF
--- a/src/hooks/useRedeem.ts
+++ b/src/hooks/useRedeem.ts
@@ -7,7 +7,7 @@ import { ethers } from "ethers";
 import { getKpiOptionsEMP, getKpiTokenContract } from "../utils";
 
 // max uint value is 2^256 - 1
-const MAX_UINT_VAL = ethers.BigNumber.from(2).pow(256).sub(1);
+const MAX_UINT_VAL = ethers.constants.MaxUint256;
 const INFINITE_APPROVAL_AMOUNT = MAX_UINT_VAL;
 
 export function useRedeem() {

--- a/src/hooks/useRedeem.ts
+++ b/src/hooks/useRedeem.ts
@@ -21,12 +21,18 @@ export function useRedeem() {
       const kpiOptionsToken = getKpiTokenContract(signer, chainId);
       const emp = getKpiOptionsEMP(signer, chainId);
 
-      const approveTx = await kpiOptionsToken.approve(
-        emp.address,
-        ethers.utils.parseEther("20000000000000000000")
-      );
-      addTransaction({ ...approveTx, label: "approve" });
-      await approveTx.wait();
+      const allowance = await kpiOptionsToken.allowance(account, emp.address);
+      const balance = await kpiOptionsToken.balanceOf(account);
+      const hasToApprove = allowance.lt(balance);
+      if (hasToApprove) {
+        const approveTx = await kpiOptionsToken.approve(
+          emp.address,
+          ethers.utils.parseEther("20000000000000000000")
+        );
+
+        addTransaction({ ...approveTx, label: "approve" });
+        await approveTx.wait();
+      }
       const onComplete = () => {
         // This will refetch all queries that have a key starting with "balance"
         queryClient.invalidateQueries("balance");

--- a/src/hooks/useRedeem.ts
+++ b/src/hooks/useRedeem.ts
@@ -6,6 +6,10 @@ import { useTransactions } from "./useTransactions";
 import { ethers } from "ethers";
 import { getKpiOptionsEMP, getKpiTokenContract } from "../utils";
 
+// max uint value is 2^256 - 1
+const MAX_UINT_VAL = ethers.BigNumber.from(2).pow(256).sub(1);
+const INFINITE_APPROVAL_AMOUNT = MAX_UINT_VAL;
+
 export function useRedeem() {
   const { account, signer, chainId } = useConnection();
   const [error, setError] = React.useState<Error>();
@@ -27,7 +31,7 @@ export function useRedeem() {
       if (hasToApprove) {
         const approveTx = await kpiOptionsToken.approve(
           emp.address,
-          ethers.utils.parseEther("20000000000000000000")
+          INFINITE_APPROVAL_AMOUNT
         );
 
         addTransaction({ ...approveTx, label: "approve" });


### PR DESCRIPTION
**Motivation**
This PR adds an allowance check before sending multiple approve transactions, to prevent users wasting money on useless approvals.

**Details**

To test this:
- Set up an env where you can redeem KPI options (can be local or the preview on Kovan / Mainnet)
- Approve the options tokens, then exit the redeem flow and refresh the page.
- You should now be able to redeem without approving again

**Testing**

Check a box to describe how you tested these changes and list the steps for reviewers to test.

- [ ]  Ran end-to-end test, running the code as in production
- [ ]  New unit tests created
- [ ]  Existing tests adequate, no new tests required
- [x]  All existing tests pass
- [ ]  Untested





Signed-off-by: Gamaranto <francesco@umaproject.org>